### PR TITLE
Fixed SyntaxError in CMS_PLACEHOLDER_CONF docs (#6003)	

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 === 3.4.5 (unreleased) ===
 
 * Fixed a bug where slug wouldn't be generated in the creation wizard
+* Fixed a bug where the add page endpoint rendered ``Change page`` as the html title.
 
 
 === 3.4.4 (unreleased) ===

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,7 +5,7 @@
 * Fixed an issue where non-staff users could request the wizard create endpoint.
 
 
-=== 3.4.4 (unreleased) ===
+=== 3.4.4 (2017-06-15) ===
 
 * Fixed a bug in which cancelling the publishing dialog wasn't respected.
 * Fixed a bug causing post-login redirection to an incorrect URL on single-language sites.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@
 
 * Fixed a bug where slug wouldn't be generated in the creation wizard
 * Fixed a bug where the add page endpoint rendered ``Change page`` as the html title.
+* Fixed an issue where non-staff users could request the wizard create endpoint.
 
 
 === 3.4.4 (unreleased) ===

--- a/cms/templates/admin/cms/page/change_form.html
+++ b/cms/templates/admin/cms/page/change_form.html
@@ -1,7 +1,7 @@
 {% extends "admin/change_form.html" %}
 {% load i18n admin_urls admin_static admin_modify cms_admin cms_static %}
 
-{% block title %}{% trans "Change a page" %}{% endblock %}
+{% block title %}{% if add %}{% trans 'Add a page' %}{% else %}{% trans "Change a page" %}{% endif %}{% endblock %}
 
 {% block breadcrumbs %}
 <div class="breadcrumbs">

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -146,9 +146,11 @@ class PageTest(PageTestBase):
         Test that the add admin page could be displayed via the admin
         """
         superuser = self.get_superuser()
+
         with self.login_user_context(superuser):
             response = self.client.get(URL_CMS_PAGE_ADD)
             self.assertEqual(response.status_code, 200)
+            self.assertContains(response, '<title>Add a page</title>', html=True)
 
     def test_create_page_admin(self):
         """
@@ -282,6 +284,7 @@ class PageTest(PageTestBase):
             page = Page.objects.get(title_set__slug=page_data['slug'], publisher_is_draft=True)
             response = self.client.get(URL_CMS_PAGE_CHANGE % page.id)
             self.assertEqual(response.status_code, 200)
+            self.assertContains(response, '<title>Change a page</title>', html=True)
             page_data['title'] = 'changed title'
             response = self.client.post(URL_CMS_PAGE_CHANGE % page.id, page_data)
             self.assertRedirects(response, URL_CMS_PAGE)

--- a/cms/tests/test_wizards.py
+++ b/cms/tests/test_wizards.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from django import forms
+from django.core.urlresolvers import reverse
 from django.core.exceptions import ImproperlyConfigured
 from django.forms.models import ModelForm
 from django.template import TemplateSyntaxError
@@ -130,6 +131,17 @@ class TestWizardBase(WizardTestMixin, TransactionCMSTestCase):
         self.assertEqual(self.user_settings_wizard.get_model(), UserSettings)
         with self.assertRaises(ImproperlyConfigured):
             self.title_wizard.get_model()
+
+    def test_endpoint_auth_required(self):
+        endpoint = reverse('cms_wizard_create')
+        staff_active = self._create_user("staff-active", is_staff=True, is_superuser=False, is_active=True)
+
+        response = self.client.get(endpoint)
+        self.assertEqual(response.status_code, 403)
+
+        with self.login_user_context(staff_active):
+            response = self.client.get(endpoint)
+            self.assertEqual(response.status_code, 200)
 
 
 class TestWizardPool(WizardTestMixin, CMSTestCase):

--- a/cms/wizards/views.py
+++ b/cms/wizards/views.py
@@ -4,9 +4,9 @@ import os
 
 from django.forms import Form
 from django.conf import settings
+from django.core.exceptions import PermissionDenied
 from django.core.files.storage import FileSystemStorage
 from django.core.urlresolvers import NoReverseMatch
-
 from django.template.response import SimpleTemplateResponse
 from django.utils.translation import get_language_from_request
 
@@ -33,6 +33,13 @@ class WizardCreateView(SessionWizardView):
         # the real form will be loaded after step 0
         ('1', Form),
     ]
+
+    def dispatch(self, *args, **kwargs):
+        user = self.request.user
+
+        if not user.is_active or not user.is_staff:
+            raise PermissionDenied
+        return super(WizardCreateView, self).dispatch(*args, **kwargs)
 
     def get_current_step(self):
         """Returns the current step, if possible, else None."""

--- a/docs/introduction/install.rst
+++ b/docs/introduction/install.rst
@@ -8,7 +8,7 @@ We'll get started by setting up our environment.
 Requirements
 ************
 
-django CMS requires Django 1.8, and Python 2.7, 3.3 or 3.4.
+django CMS requires Django 1.8, 1.9 or 1.10 and Python 2.7, 3.3 or 3.4.
 
 ************************
 Your working environment

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -190,7 +190,7 @@ Example::
         None: {
             "plugins": ['TextPlugin'],
             'excluded_plugins': ['InheritPlugin'],
-        }
+        },
         'content': {
             'plugins': ['TextPlugin', 'PicturePlugin'],
             'text_only_plugins': ['LinkPlugin'],


### PR DESCRIPTION
### Summary

<!-- If this is a security-related patch stop right here and email security@django-cms.org instead -->

Fixes #



### Links to related discussion



### Proposed changes in this pull request
