### PR TITLE
Fixed #6021 -- Render inherited content even when the parent is cache…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,8 @@
 * Fixed an issue where non-staff users could request the wizard create endpoint.
 * Fixed an issue where the ``Edit page`` toolbar button wouldn't show on non-cms pages
   with placeholders.
+* Fixed a bug where placeholder inheritance wouldn't work if the inherited placeholder
+  is cached in an ancestor page.
 
 
 === 3.4.4 (2017-06-15) ===

--- a/cms/tests/test_rendering.py
+++ b/cms/tests/test_rendering.py
@@ -558,6 +558,18 @@ class RenderingTestCase(CMSTestCase):
         r = self.render(self.test_page6)
         self.assertEqual(r, u'|' + self.test_data5['text_main'] + '|' + self.test_data6['text_sub'])
 
+    def test_inherit_placeholder_with_cache(self):
+        expected = u'|' + self.test_data5['text_main'] + '|' + self.test_data6['text_sub']
+        # Render the top-most page
+        # This will cache its contents
+        self.render(self.test_page)
+        # Render the parent page
+        # This will cache its contents
+        self.render(self.test_page5)
+        # Render the target page
+        # This should use the cached parent page content
+        self.assertEqual(self.render(self.test_page6), expected)
+
     def test_inherit_placeholder_override(self):
         # Tests that the user can override the inherited content
         # in a placeholder by adding plugins to the inherited placeholder.


### PR DESCRIPTION
…d (#6023)

### Summary

<!-- If this is a security-related patch stop right here and email security@django-cms.org instead -->

Fixes #



### Links to related discussion



### Proposed changes in this pull request
